### PR TITLE
Dr hf 31326

### DIFF
--- a/get-started/aide-architecture.adoc
+++ b/get-started/aide-architecture.adoc
@@ -69,7 +69,7 @@ You can access it through ONTAP System Manager.
 Data Sync is an automated background service that ensures that the metadata catalog and data collections remain current and consistent with the underlying data sources, even as source data changes.
 
 .License and access
-Data Sync functionality is not included with the base ONTAP One license and requires a separate AIDE license.
+Data Sync functionality is included with the base ONTAP One license and is available upon AIDE installation.
 
 .Capabilities
 

--- a/install-setup/cable-hardware.adoc
+++ b/install-setup/cable-hardware.adoc
@@ -21,6 +21,7 @@ NOTE: You do not need to power off the AFX 1K storage system when cabling the da
 * You have an existing AFX 1K storage system installed. For information on installing the AFX 1K storage system, refer to link:https://docs.netapp.com/us-en/ontap-afx/install-setup/install-setup-workflow.html[AFX 1K storage system installation documentation^].
 * You have the required network switches installed and configured. Contact your network administrator for information about connecting the system to your network switches.
 * You have reviewed the link:../install-setup/cable-overview.html[cabling requirements for the data compute nodes].
+* A minimum of three data compute nodes are required to deploy the AI Data Engine. 
 
 == Step 1: Connect the data compute nodes to the host network
 You can connect the data compute node ports to your host network. 
@@ -51,7 +52,7 @@ image::../media/drw_aide_network_cabling_b_ieops-2648.svg[Cable to Ethernet netw
 
 
 == Step 2: Cable the data compute node cluster connections
-For data compute nodes, the e4a/e5a ports are used for the cluster connections. 
+For data compute nodes, use 4x100GbE breakout cables to connect the e4a/e5a ports for the cluster connections. 
 
 .Steps
 . Connect port e4a from the following data compute nodes to a non-ISL port on cluster network switch A:
@@ -59,7 +60,7 @@ For data compute nodes, the e4a/e5a ports are used for the cluster connections.
 * Data Compute Node 1, port e4a
 * Data Compute Node 2, port e4a
 +
-*100GbE cables*
+*4x100GbE breakout cables*
 +
 image::../media/oie_cable100_gbe_qsfp28.png[100 Gb Ethernet cable]
 +
@@ -70,7 +71,7 @@ image::../media/drw_aide_switched_cluster_cabling_a_ieops-2649.svg[Cable to Ethe
 * Data Compute Node 1, port e5a
 * Data Compute Node 2, port e5a
 +
-*100GbE cables*
+*4x100GbE breakout cables*
 +
 image::../media/oie_cable100_gbe_qsfp28.png[100 Gb Ethernet cable]
 +

--- a/install-setup/cable-hardware.adoc
+++ b/install-setup/cable-hardware.adoc
@@ -21,7 +21,8 @@ NOTE: You do not need to power off the AFX 1K storage system when cabling the da
 * You have an existing AFX 1K storage system installed. For information on installing the AFX 1K storage system, refer to link:https://docs.netapp.com/us-en/ontap-afx/install-setup/install-setup-workflow.html[AFX 1K storage system installation documentation^].
 * You have the required network switches installed and configured. Contact your network administrator for information about connecting the system to your network switches.
 * You have reviewed the link:../install-setup/cable-overview.html[cabling requirements for the data compute nodes].
-* A minimum of three data compute nodes are required to deploy the AI Data Engine. 
+
+NOTE: A minimum of three data compute nodes are required to deploy the AI Data Engine. 
 
 == Step 1: Connect the data compute nodes to the host network
 You can connect the data compute node ports to your host network. 

--- a/install-setup/install-workflow.adoc
+++ b/install-setup/install-workflow.adoc
@@ -17,7 +17,7 @@ Ensure that you have an existing AFX 1K storage system installed, and then revie
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-2.png[Two]link:prepare-hardware.html[Prepare to install your data compute nodes]
 [role="quick-margin-para"]
-To prepare to install your data compute nodes, you need to get the site ready, check the environmental and electrical requirements, and ensure there's enough cabinet space. Then, unpack the equipment, compare its contents to the packing slip, and register the hardware to access support benefits.
+To prepare to install your data compute nodes, you need to get the site ready, check the environmental and electrical requirements, and ensure there's enough cabinet space. Then, unpack the equipment, compare its contents to the packing slip, and register the hardware to access support benefits. A minimum of three data compute nodes are required to deploy the AI Data Engine. 
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-3.png[Three]link:deploy-hardware.html[Install the hardware for your data compute nodes]
 [role="quick-margin-para"]
@@ -25,7 +25,7 @@ Install the rail kits for your data compute nodes. Secure your data compute node
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-4.png[Four]link:cable-hardware.html[Cable your data compute nodes]
 [role="quick-margin-para"]
-To cable the hardware, first connect the data compute nodes to your data and cluster network, then connect the data compute nodes to the cluster switches.
+To cable the hardware, first connect the data compute nodes to your data network, then connect the data compute nodes to the cluster switches.
 
 .image:https://raw.githubusercontent.com/NetAppDocs/common/main/media/number-5.png[Five]link:power-on-hardware.html[Power on your data compute nodes]
 [role="quick-margin-para"]


### PR DESCRIPTION
This pull request updates the installation and setup documentation for the AI Data Engine, clarifying hardware requirements and improving cabling instructions. The most significant changes clarify the minimum number of required data compute nodes, update licensing information, and specify the cabling requirements for cluster connections.

**Hardware requirements and licensing:**

* Updated documentation to state that a minimum of three data compute nodes are required to deploy the AI Data Engine, adding this requirement to both the installation workflow and cabling prerequisites. [[1]](diffhunk://#diff-277e71c7dc7f0214b5061e44d48e28637b35e0c7ae6de5e50f2f653be4c3249cL20-R28) [[2]](diffhunk://#diff-77d556767542c6c0e8871a74065a117b23fc813dae01d93cfcd562e26bae313eR25-R26)
* Clarified that Data Sync functionality is now included with the base ONTAP One license and is available upon AIDE installation, removing the need for a separate AIDE license.

**Cabling instructions:**

* Updated cabling steps to specify the use of 4x100GbE breakout cables (instead of generic 100GbE cables) for connecting the e4a/e5a ports of data compute nodes to the cluster network switches. [[1]](diffhunk://#diff-77d556767542c6c0e8871a74065a117b23fc813dae01d93cfcd562e26bae313eL54-R64) [[2]](diffhunk://#diff-77d556767542c6c0e8871a74065a117b23fc813dae01d93cfcd562e26bae313eL73-R75)
* Clarified the cabling workflow step to distinguish between connecting to the data network and the cluster switches, improving installation clarity.